### PR TITLE
Onedrive backups guide

### DIFF
--- a/dime-research-standards/README.md
+++ b/dime-research-standards/README.md
@@ -1,6 +1,6 @@
 # DIME Research Standards
 
-All DIME research projects are expected to comply with the following requirements: 
+All DIME research projects are expected to comply with the following requirements:
 
 ## Pillar 1 - Research Ethics
 For implementation resources, see the [Research Ethics Guidelines](https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-1-research-ethics)
@@ -34,7 +34,7 @@ For implementation resources, see the [Data Security Guidelines](https://github.
     - Encryption at rest must be implemented so that no person not listed on the IRB ever has access to the decryption key or the unencrypted data. This includes server hosts or administrators, sharing or syncing service providers, internet providers, and staff not listed on the IRB at any institution.
   - All identified data must be stored only in securely encrypted locations,
   and must always be encrypted when shared, even if shared only within the project team (link to DIME Encryption Protocol)
-  - World Bank PIs should back up raw data in a WB OneDrive folder that is not shared with anyone, and is not synced to any computer.
+  - World Bank PIs should back up raw data in a [WB OneDrive folder](https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/onedrive-backup-guidelines.md) that is not shared with anyone, and is not synced to any computer.
 - The project team should create a [de-identified](https://dimewiki.worldbank.org/wiki/De-identification) copy of the
 primary data before starting data cleaning and analysis,
 removing most sensitive information (e.g. names) even if some identifying information

--- a/dime-research-standards/pillar-4-data-security/README.md
+++ b/dime-research-standards/pillar-4-data-security/README.md
@@ -3,10 +3,9 @@
 Data security is important for two reasons:
 **respecting the privacy of respondents or the terms of data licensing agreements** and
 **making sure no one publishes papers using your data before you**.
-The detailed version of the DIME Data Security Standards can be found
-[here](https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/dime-data-security-guidelines.md).
 To be fully compliant with the DIME Data Security Standards,
-a project most follow all applicable items listed in the detailed version.
+a project most follow all applicable items listed in the
+[DIME Data Security Standards (detailed version)](https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/dime-data-security-guidelines.md).
 
 ### DIME Data Non-Disclosure MOU
 
@@ -15,6 +14,12 @@ All Research Assistants and Field Coordinators at DIME must sign the
 as a condition of employment.
 
 ## DIME Data Security Resources
+
+#### Secure back-ups of raw data in WB OneDrive
+
+See
+[DIME Data Back-up Guide ](https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/onedrive-backup-guidelines.md)
+for instructions on how all DIME projects should back up their data.
 
 #### Encryption in transit
 

--- a/dime-research-standards/pillar-4-data-security/data-security-resources/onedrive-backup-guidelines.md
+++ b/dime-research-standards/pillar-4-data-security/data-security-resources/onedrive-backup-guidelines.md
@@ -1,0 +1,81 @@
+# DIME Analytics - Data Security Guides - WB OneDrive Back-up
+
+This guide is for the World Bank's Enterprise version of OneDrive (WB OneDrive),
+and not all parts of this guide should be followed using regular OneDrive, DropBox or any other synching service.
+Those services are not secure enough for us to recommend that you upload identified data
+without manually encrypt it first.
+
+A folder created in WB OneDrive cannot be synced to a non-World Bank device
+even if that person has been invited to the folder.
+This is because it is installed with extra layers of encryption that is connected to our WB computer log-ons.
+While that makes it an unsuitable tool for day-to-day collaboration with team members that do not have a World Bank computer,
+it makes it an excellent tool for back-ups of raw data,
+where there is no risk that data is lost because encryption keys are lost.
+
+## WB OneDrive back-up folders
+
+There is nothing special you have to do to set up a back-up folder in WB OneDrive, but since data back-up is such an important step, we still write a guide for it. The only way the back-up folder should differ from more most WB OneDrive folders is that this folder should not be synched to any device, and it should not be shared with anyone.
+
+You are allowed to sync identified data in WB OneDrive folders to your device,
+but since that there is a risk that you by accident delete a folder on your computer,
+you should not sync the back-up folder.
+If you want the data synced to your computer,
+create another folder that is not your back-up folder where you do so.
+
+You are allowed to share identified data with other World Bank members using WB OneDrive,
+but since there is a risk that they by accident, or because they did not know it was a back-up folder,
+delete your back-up folder, you should not share your back-up folder.
+Again, if you want to use WB OneDrive to share the data, create another folder to do so.
+If you are more than one PI in a project, then each PI can create their own WB OneDrive back-up folder.
+
+## Steps to set up a WB OneDrive back-up folder
+
+Go to [WB OneDrive](http://onedrive.worldbank.org) and create a new folder.
+We recommend that you create one top back-up folder in which you create a sub-folder for each project.
+Then you will not lose track of your back-up folders.
+We call our folder `backup-data` but you can name it whatever you want
+to make sure you never confuse this folder for another folder.
+To create a folder, click `+New` and then `Folder` and follow the instructions.
+
+<img src="https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/img/onedrive-backup-1.png" width="75%"><!--- Image is read from master branch or use full URL-->
+
+In the top back-up folder, create one folder for each project you want to back up
+by clicking `+New` and then `Folder` again.
+
+<img src="https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/img/onedrive-backup-2.png" width="75%"><!--- Image is read from master branch or use full URL-->
+
+In each project folder, create one folder for each data source you want to back up,
+by clicking `+New` and then `Folder` again.
+A data source can be a survey round (baseline, endline etc.),
+admin data (data shared with us from government counter parts) etc.
+The main difference between data sources relevant to back-ups are if they are
+continuous (meaning we keep getting new data) or
+discrete (meaning that once we have the data set it will not be updated again).
+
+An example of a discrete source of data is a typical survey round.
+Once we are done collecting data we will not get more data for that survey round.
+That data should be backed up in WB OneDrive after the data collection is completed
+but before the data collection server is closed down.
+For continuous data sources there is no equally obvious point when the data should be backed up,
+but it should be often enough that a potential loss of data between back-ups
+is not too devastating for the project.
+
+<img src="https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/img/onedrive-backup-3.png" width="75%"><!--- Image is read from master branch or use full URL-->
+
+Once you have created the folder for your data source,
+simply drag all the files you want to back up here.
+You can drag a whole folder and all its content at the same time.
+You should back up the most raw version of your data, even if that is a bunch of csv files.
+Since storage space will not be an issue since you will not sync this folder,
+you can back up both the rawest files and a data set where all of them are merged.
+Even if these files are identifying you do not need to manually encrypt them before uploading them.
+
+<img src="https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/img/onedrive-backup-4.png" width="75%"><!--- Image is read from master branch or use full URL-->
+
+You will see the file in your back-up folder once it is done uploading.
+If you want to upload more files you just keep dragging them there.
+Then you are done and your files are securely backed up.
+Close your browser and do not navigate to this folder more than necessary
+to minimize the risk that you delete a file by mistake.
+
+<img src="https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/img/onedrive-backup-5.png" width="75%"><!--- Image is read from master branch or use full URL-->

--- a/dime-research-standards/pillar-4-data-security/data-security-resources/onedrive-backup-guidelines.md
+++ b/dime-research-standards/pillar-4-data-security/data-security-resources/onedrive-backup-guidelines.md
@@ -1,20 +1,20 @@
 # DIME Analytics - Data Security Guides - WB OneDrive Back-up
 
 This guide is for the World Bank's Enterprise version of OneDrive (WB OneDrive),
-and not all parts of this guide should be followed using regular OneDrive, DropBox or any other synching service.
-Those services are not secure enough for us to recommend that you upload identified data
-without manually encrypt it first.
+and not all parts of this guide should be followed using regular OneDrive, DropBox or any other syncing service.
+The non WB OneDrive sync services are not secure enough for us to recommend for uploading identified data
+without manually encrypting it first.
 
 A folder created in WB OneDrive cannot be synced to a non-World Bank device
-even if that person has been invited to the folder.
+even if owner of that device has been invited to the folder.
 This is because it is installed with extra layers of encryption that is connected to our WB computer log-ons.
 While that makes it an unsuitable tool for day-to-day collaboration with team members that do not have a World Bank computer,
 it makes it an excellent tool for back-ups of raw data,
-where there is no risk that data is lost because encryption keys are lost.
+where there is no risk of losing data as a result of loss of encryption keys.
 
 ## WB OneDrive back-up folders
 
-There is nothing special you have to do to set up a back-up folder in WB OneDrive, but since data back-up is such an important step, we still write a guide for it. The only way the back-up folder should differ from more most WB OneDrive folders is that this folder should not be synched to any device, and it should not be shared with anyone.
+While an easy process, setting up a back-up folder in WB OneDrive is an extremely important process.  The only way the back-up folder should differ from more most WB OneDrive folders is that this folder should not be synced to any device, and it should not be shared with anyone.
 
 You are allowed to sync identified data in WB OneDrive folders to your device,
 but since that there is a risk that you by accident delete a folder on your computer,
@@ -66,8 +66,8 @@ Once you have created the folder for your data source,
 simply drag all the files you want to back up here.
 You can drag a whole folder and all its content at the same time.
 You should back up the most raw version of your data, even if that is a bunch of csv files.
-Since storage space will not be an issue since you will not sync this folder,
-you can back up both the rawest files and a data set where all of them are merged.
+Since storage space will not be an issue as you will not sync this folder,
+you can back up both, the rawest files and a data set created from the raw files.
 Even if these files are identifying you do not need to manually encrypt them before uploading them.
 
 <img src="https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/img/onedrive-backup-4.png" width="75%"><!--- Image is read from master branch or use full URL-->

--- a/dime-research-standards/pillar-4-data-security/dime-data-security-guidelines.md
+++ b/dime-research-standards/pillar-4-data-security/dime-data-security-guidelines.md
@@ -68,7 +68,7 @@ and needs to be encrypted as it is saved to the local computer.
 
 ## Storing confidential data
 
-PIs should save a copy of the unaltered raw data in a WB OneDrive folder as backup.
+PIs should save a copy of the unaltered raw data in a [WB OneDrive folder as backup](https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/onedrive-backup-guidelines.md).
 * This folder should not be synced to any computer, and it should not be shared with anyone, so it remains completely under individual control.
 * If there are multiple PIs on a project,
 each of them can save a backup of the data _separately_ for added layers of security.


### PR DESCRIPTION
As I was going through my presentation I realized we should have a guide for how to backup on WB OneDrive.

Nothing complicated, but there should be a guide that PIs should be able to quickly follow.

The links I added to this guide in the different README will only work once this is merged to master. I do not want to have to fix it then.